### PR TITLE
travis-ci: use nixopsUnstable for evaluation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script:
   - ./Cardano_csl.hs --help
   - ./Cardano_tw.hs --help
   - nix-instantiate default.nix  
-  - nix-instantiate nixops.nix
+  - nix-shell -p nixopsUnstable --run "nixops create nixops.nix && nixops deploy --evaluate-only"
   - GENERATING_AMI=1 nix-instantiate release.nix
 
 notifications:


### PR DESCRIPTION
This has to wait until https://github.com/NixOS/nixpkgs/commit/ce6abb9495b6cf22f3b1ac74df713cc2a999276f hits the channels.