### PR TITLE
Manually start cardano-node

### DIFF
--- a/CardanoCSL.hs
+++ b/CardanoCSL.hs
@@ -122,8 +122,6 @@ runexperiment = do
   echo "Checking nodes' status, rebooting failed"
   checkstatus args
   --deploy
-  echo "Stopping nodes..."
-  stopCardanoNodes nodes
   echo "Starting nodes..."
   startCardanoNodes nodes
   echo "Delaying... (30s)"
@@ -141,6 +139,8 @@ postexperiment = do
   nodes <- getNodes args
   echo "Checking nodes' status, rebooting failed"
   checkstatus args
+  echo "Stopping nodes..."
+  stopCardanoNodes nodes
   echo "Retreive logs..."
   dt <- dumpLogs True nodes
   cliCmd <- getSmartGenCmd

--- a/modules/cardano-node.nix
+++ b/modules/cardano-node.nix
@@ -92,7 +92,6 @@ in
 
     systemd.services.cardano-node = {
       description   = "cardano node service";
-      wantedBy      = [ "multi-user.target" ];
       after         = [ "network.target" ];
       serviceConfig = {
         User = "cardano-node";


### PR DESCRIPTION
In order to avoid high load during deployment, start cardano-node only during experiments.